### PR TITLE
Use support library 25.3.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,5 +1,5 @@
 ext {
-    supportVersion = '25.4.0'
+    supportVersion = '25.3.0'
     support = [
         annotations : "com.android.support:support-annotations:$supportVersion",
         appcompat : "com.android.support:appcompat-v7:$supportVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 groupId = com.saantiaguilera.securekeys
-libraryVersion = 2.0.1
+libraryVersion = 2.1.0
 
 # Plugin versions
 libraryDynamicVersion = 2.+


### PR DESCRIPTION
## Description 

To avoid having people to use 25.4.0 and the google() repository of maven, im switching to 25.3.0 until gradle 4.0 is stable / android 3.0.0 too (Im guessing from logic they will add the google() maven url)

## Issues fixed 

- fixes #31 