### PR TITLE
Publish 2.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 groupId = com.saantiaguilera.securekeys
-libraryVersion = 2.1.0
+libraryVersion = 2.2.0
 
 # Plugin versions
 libraryDynamicVersion = 2.+

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -3,5 +3,4 @@ dependencies {
 
     testCompile testing.googleTruth
     testCompile testing.googleTesting
-    testCompile files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
 }


### PR DESCRIPTION
## Description 

Publish 2.2.0, this includes:
- Fixes for plugin breaking from the gradle sync when initializing
- Problems with native modules

For more information please see the milestone 2.2.0