### PR TITLE
Fix issue with extern_consts not found in sync

### DIFF
--- a/core/src/main/cpp/extern_consts.h
+++ b/core/src/main/cpp/extern_consts.h
@@ -1,0 +1,19 @@
+// Empty default template file
+
+#ifndef SECUREKEYS_EXTERN_CONSTS_H
+#define SECUREKEYS_EXTERN_CONSTS_H
+
+#include <map>
+#include <string>
+
+#define SECUREKEYS_HALT_IF_DEBUGGABLE false
+#define SECUREKEYS_HALT_IF_EMULATOR false
+#define SECUREKEYS_HALT_IF_ADB_ON false
+#define SECUREKEYS_HALT_IF_PHONE_NOT_SECURE false
+#define SECUREKEYS_INSTALLERS { }
+#define SECUREKEYS_SIGNING_CERTIFICATE ""
+#define SECUREKEYS_AES_KEY { }
+#define SECUREKEYS_AES_INITIAL_VECTOR { }
+#define SECUREKEYS_LOAD_MAP(_map) ;
+
+#endif //SECUREKEYS_EXTERN_CONSTS_H

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,7 +17,7 @@ org.gradle.jvmargs=-Xmx1536m
 # org.gradle.parallel=true
 
 groupId = com.saantiaguilera.securekeys
-libraryVersion = 2.2.0
+libraryVersion = 2.2.1
 
 # Plugin versions
 libraryDynamicVersion = 2.+

--- a/plugin/src/main/groovy/com/saantiaguilera/securekeys/gradle/NativePackagerPlugin.groovy
+++ b/plugin/src/main/groovy/com/saantiaguilera/securekeys/gradle/NativePackagerPlugin.groovy
@@ -25,7 +25,7 @@ class NativePackagerPlugin implements Plugin<Project> {
     private static final String FILE_BLOB_H = 'main/cpp/**/*.h'
     private static final String FILE_BLOB_SO = '**/*.so'
     private static final String FILE_BLOB_ALL = '**'
-    private static final String FILE_BLOB_EXTERNAL_HEADERS = 'main/cpp/**/extern_*.h'
+    //private static final String FILE_BLOB_EXTERNAL_HEADERS = 'main/cpp/**/extern_*.h'
 
     private static final HashMap<String, String> CPP_FLAGS = [
             std: "c++11",
@@ -62,7 +62,7 @@ class NativePackagerPlugin implements Plugin<Project> {
 
         task.from project.zipTree("${path}${project.name}-${variant}.${AAR}")
         task.exclude(FILE_BLOB_SO) // Do not include shared libraries into final AAR
-        task.exclude(FILE_BLOB_EXTERNAL_HEADERS) // Do not include extern_**.h classes to the final AAR
+        //task.exclude(FILE_BLOB_EXTERNAL_HEADERS) // Do not include extern_**.h classes to the final AAR
         task.from("src") {
             include(FILE_BLOB_H)
             include(FILE_BLOB_CPP)


### PR DESCRIPTION
## Description 

In 2.2.0 when syncing although it unpacks the native files, the sync wont trigger the annotation processor, making the cmake fail (as it doesnt found the `extern_consts` file)