### PR TITLE
Fix mixed up parameter order in `memset()`

### DIFF
--- a/core/src/main/cpp/crypto/crypto_wrapper.cpp
+++ b/core/src/main/cpp/crypto/crypto_wrapper.cpp
@@ -29,7 +29,7 @@ std::string CryptoWrapper::decode_value(std::string value) {
         free(input);
         throw "Couldnt assign memmory for buffer inside decode";
     }
-    memset(buff, src_len, 0);
+    memset(buff, 0, src_len);
 
     // Set key and iv
     unsigned int key_schedule[AES_BLOCK_SIZE * 4] = { 0 };


### PR DESCRIPTION
## Description 

A call to `memset()` mixed up the `c` and `n` parameters. Fixed.